### PR TITLE
Update ChargebackRetrieval.php

### DIFF
--- a/cnp/sdk/ChargebackRetrieval.php
+++ b/cnp/sdk/ChargebackRetrieval.php
@@ -93,7 +93,7 @@ class ChargebackRetrieval
     private function getRetrievalResponse($parameters)
     {
         $urlSuffix = self::SERVICE_ROUTE;
-        $prefix = "?";
+        $prefix = "/?";
         foreach ($parameters as $key => $value) {
             $urlSuffix .= $prefix . $key . "=" . $value;
             $prefix = "&";


### PR DESCRIPTION
The slash is supplied in the getChargebackByCaseId method (Line 54), but not in the getRetrievalResponse method (Line 96).

The getRetrievalResponse method works with the proposed change.